### PR TITLE
Add not null assertions to Command subclasses

### DIFF
--- a/src/main/java/duke/command/AddTaskCommand.java
+++ b/src/main/java/duke/command/AddTaskCommand.java
@@ -13,6 +13,7 @@ public class AddTaskCommand extends Command {
     private final Task newTask;
 
     public AddTaskCommand(Task newTask) {
+        assert newTask != null;
         this.newTask = newTask;
     }
 

--- a/src/main/java/duke/command/DeleteCommand.java
+++ b/src/main/java/duke/command/DeleteCommand.java
@@ -23,6 +23,9 @@ public class DeleteCommand extends Command {
 
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) throws DukeException {
+        assert tasks != null;
+        assert ui != null;
+        assert storage != null;
         Task removed = tasks.remove(index);
         storage.saveTasks(tasks);
         return ui.showTaskDeleted(removed, tasks.size());

--- a/src/main/java/duke/command/ExitCommand.java
+++ b/src/main/java/duke/command/ExitCommand.java
@@ -16,6 +16,7 @@ public class ExitCommand extends Command {
 
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) throws DukeException {
+        assert ui != null;
         return ui.showExitMessage();
     }
 }

--- a/src/main/java/duke/command/FindCommand.java
+++ b/src/main/java/duke/command/FindCommand.java
@@ -23,6 +23,7 @@ public class FindCommand extends Command {
 
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) throws DukeException {
+        assert tasks != null;
         String tasksFound = tasks.findTasks(this.query);
         if (tasksFound.isEmpty()) {
             return Messages.MESSAGE_NO_TASKS_FOUND;

--- a/src/main/java/duke/command/ListCommand.java
+++ b/src/main/java/duke/command/ListCommand.java
@@ -16,6 +16,7 @@ public class ListCommand extends Command {
 
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) throws DukeException {
+        assert ui != null;
         return ui.showList(tasks);
     }
 }

--- a/src/main/java/duke/command/MarkCommand.java
+++ b/src/main/java/duke/command/MarkCommand.java
@@ -23,6 +23,9 @@ public class MarkCommand extends Command {
 
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) throws DukeException {
+        assert tasks != null;
+        assert ui != null;
+        assert storage != null;
         Task currentTask = tasks.markAsDone(index);
         storage.saveTasks(tasks);
         return ui.showTaskDone(currentTask);

--- a/src/main/java/duke/command/UnmarkCommand.java
+++ b/src/main/java/duke/command/UnmarkCommand.java
@@ -23,6 +23,9 @@ public class UnmarkCommand extends Command {
 
     @Override
     public String execute(TaskList tasks, Ui ui, Storage storage) throws DukeException {
+        assert tasks != null;
+        assert ui != null;
+        assert storage != null;
         Task currentTask = tasks.markAsUndone(index);
         storage.saveTasks(tasks);
         return ui.showTaskUndone(currentTask);


### PR DESCRIPTION
The method execute in these classes do not check if the arguments passed in are null. Adding these assertions could help to prevent null pointer exceptions or improper use of the methods.